### PR TITLE
Changed the padding of the unique order id

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -276,6 +276,9 @@
   .inset-y-0 {
     inset-block: calc(var(--spacing) * 0);
   }
+  .spacing-top {
+    padding-top: calc(var(--spacing) * 5);
+  }
   .-top-1 {
     top: calc(var(--spacing) * -1);
   }

--- a/orders.php
+++ b/orders.php
@@ -1417,7 +1417,7 @@ include "backend/dashboard.php";
                                             <img src="${imgSrc}" alt="Product" class="w-full h-full object-contain">
                                         </div>
                                         <div class="flex-1 min-w-0">
-                                            <p class="font-semibold text-gray-900 text-xs truncate-text">Order #${orderId}</p>
+                                            <p class="spacing-top font-semibold text-gray-900 text-xs truncate-text">Order #${orderId}</p>
                                             <p class="text-xs text-gray-500 truncate-text mt-4">${order.customer_name || order.product_title || 'Customer'}</p>
                                             <div class="flex items-center justify-between">
                                                 <p class="font-bold text-gray-900 text-xs">₹${order.amount || order.product_price || '0'}</p>
@@ -1483,7 +1483,7 @@ include "backend/dashboard.php";
                                             <img src="${imgSrc}" alt="Product" class="w-full h-full object-contain">
                                         </div>
                                         <div class="flex-1 min-w-0">
-                                            <p class="font-semibold text-gray-900 text-sm truncate-text">Order #${orderId}</p>
+                                            <p class="spacing-top font-semibold text-gray-900 text-sm truncate-text">Order #${orderId}</p>
                                             <p class="text-xs text-gray-500 truncate-text mt-1">${order.customer_name || order.product_title || 'Customer'}</p>
                                             <div class="flex items-center justify-between">
                                                 <p class="font-bold text-gray-900 text-sm">₹${order.amount || order.product_price || '0'}</p>


### PR DESCRIPTION
**Ticket: Fix Repeated Order ID (#188) in Live Order Cards**
[https://app.clickup.com/t/86czxaeu1](url)

All live order cards on the Orders page currently display the same order ID #188, regardless of the actual order details in desktop view. But the main issue is the button (Finding delivery boy) is closing the remaining unique id. So, just change the padding of the order id in the card. For that reason I changed the padding of the order id in both desktop and mobile view for better visibility