### PR TITLE
Adjusted the alignment of items inside the card in both views

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -1417,11 +1417,11 @@ include "backend/dashboard.php";
                                             <img src="${imgSrc}" alt="Product" class="w-full h-full object-contain">
                                         </div>
                                         <div class="flex-1 min-w-0">
-                                            <p class="font-semibold text-gray-900 text-xs truncate-text">Order #${orderId}</p>
-                                            <p class="text-xs text-gray-500 truncate-text mt-4">${order.customer_name || order.product_title || 'Customer'}</p>
+                                            <p class="mt-6 font-semibold text-gray-900 text-xs truncate-text">Order #${orderId}</p>
+                                            <p class="text-xs text-gray-500 truncate-text mt-1">${order.customer_name || order.product_title || 'Customer'}</p>
                                             <div class="flex items-center justify-between">
                                                 <p class="font-bold text-gray-900 text-xs">₹${order.amount || order.product_price || '0'}</p>
-                                                <p class="text-xs text-gray-500 ml-4">${order.order_time || order.date || 'Just now'}</p>
+                                                <p class="text-xs text-gray-500 ml-4 mt-1">${order.order_time || order.date || 'Just now'}</p>
                                             </div>
                                         </div>
                                     </div>
@@ -1483,11 +1483,11 @@ include "backend/dashboard.php";
                                             <img src="${imgSrc}" alt="Product" class="w-full h-full object-contain">
                                         </div>
                                         <div class="flex-1 min-w-0">
-                                            <p class="font-semibold text-gray-900 text-sm truncate-text">Order #${orderId}</p>
+                                            <p class="mt-6 font-semibold text-gray-900 text-sm truncate-text">Order #${orderId}</p>
                                             <p class="text-xs text-gray-500 truncate-text mt-1">${order.customer_name || order.product_title || 'Customer'}</p>
                                             <div class="flex items-center justify-between">
                                                 <p class="font-bold text-gray-900 text-sm">₹${order.amount || order.product_price || '0'}</p>
-                                                <p class="text-xs text-gray-500">${order.order_time || order.date || 'Just now'}</p>
+                                                <p class="text-xs text-gray-500 ml-4 mt-1">${order.order_time || order.date || 'Just now'}</p>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
**Ticket: Alignment Issues in Live Order Cards**
[https://app.clickup.com/t/86czxhmre](url)


All live order cards on the Orders page currently is not visually balanced. Elements like product image, price, date, and status are cramped together, making the cards look cluttered and harder to read. 

So, Adjusted the alignment of items inside the card by taking margin for better visibility