### PR TITLE
Changed the spelling of 'make' text to correctly in upgrade card of Orders Page

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -522,7 +522,7 @@ include "backend/dashboard.php";
       <span>Best plan</span>
     </div>
 
-    <div class="total">Makae your store visible</div>
+    <div class="total">Make your store visible</div>
     <div class="amount">@199/m</div>
 
     <div class="action">


### PR DESCRIPTION
**Ticket: Spelling Correction in Upgrade Card Text in Mobile View**
[https://app.clickup.com/t/86czxmev0](url)

In the mobile view Upgrade to Premium card, the text currently displays:
"Makae your store visible".
I corrected the spelling to: "Make your store visible"