### PR TITLE
Changed the Profile Name to Proper Case in Orders Page

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -431,7 +431,11 @@ include "backend/dashboard.php";
                         <div class="w-8 h-8 bg-gradient-to-r from-green-400 to-blue-500 rounded-full flex items-center justify-center">
                             <span class="text-white font-semibold text-sm">SO</span>
                         </div>
-                        <span class="text-sm font-medium text-gray-700"> <?php echo $_SESSION['name']; ?></span>
+                        <span class="text-sm font-medium text-gray-700"> 
+                            <?php 
+                                echo ucwords(strtolower($_SESSION['name'])); 
+                            ?>
+                        </span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**Orders Page Ticket: Proper Case for Profile Name Display**
[https://app.clickup.com/t/86czxkp90](url)

Changed the first and last names starting with uppercase letters. The code I added was:

```
<?php 
       echo ucwords(strtolower($_SESSION['name'])); 
 ?>
```
**strtolower($_SESSION['name']):**

- Converts the entire string in $_SESSION['name'] to lowercase.

**ucwords(...):**

- Takes a string and capitalizes the first letter of each word.


 