### PR TITLE
Added bottom margin for Page Content in mobile view

### DIFF
--- a/orders.php
+++ b/orders.php
@@ -302,6 +302,10 @@ include "backend/dashboard.php";
             #live-orders-container .live-order-card::after {
                 border-radius: 0 0 16px 16px;
             }
+
+            .bottomMargin {
+                margin-bottom: 60px;
+            }
         }
         
         /* Card content improvements */
@@ -552,7 +556,7 @@ include "backend/dashboard.php";
                     
                     <!-- Mobile Pagination Controls -->
                     <div class="md:hidden mt-6 mb-8" id="mobile-pagination-controls">
-                        <div class="bg-white rounded-2xl shadow-lg p-4">
+                        <div class="bg-white rounded-2xl shadow-lg p-4 bottomMargin">
                             <div class="flex flex-col space-y-4">
                                 <div class="flex items-center justify-between">
                                     <div class="flex items-center space-x-2">


### PR DESCRIPTION
**Orders Page Ticket: Add Bottom Margin for Page Content in Mobile View**
[https://app.clickup.com/t/86czxmmd1](url)

Added enough bottom margin so page content is fully visible above the bottom navigation bar. This ensures the last section is not cut off and can be scrolled completely.

The code I was added is:

```
.bottomMargin
 {
      margin-bottom: 60px;
 }
```