### PR TITLE
Added the bottom margin for better visibility of all product cards in Products Page

### DIFF
--- a/products.php
+++ b/products.php
@@ -42,6 +42,11 @@
             backdrop-filter: blur(10px);
             background: rgba(255, 255, 255, 0.9);
         }
+        @media (max-width: 768px) {
+            .bottomMargin {
+                margin-bottom: 60px;
+            }
+        }
     </style>
 </head>
 <body class="bg-gradient-to-br from-purple-50 to-pink-100 min-h-screen">
@@ -225,7 +230,7 @@
                 </div>
 
                 <!-- Products Grid -->
-                <div id="products-container" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-6">
+                <div id="products-container" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-6 bottomMargin">
                     <!-- Products will be dynamically loaded here -->
                     <div class="col-span-full text-center py-10">
                         <div class="animate-pulse flex flex-col items-center">


### PR DESCRIPTION
**Products Page Ticket: Bottom Scrolling of products cards in mobile view isn't good**
[https://app.clickup.com/t/86czxmm96](url)

In mobile view, while scrolling to the bottom products is looking bad, not visible to see the last product card fully. 
So, added the bottom margin for that products container

The code I was added is:

```
@media (max-width: 768px) 
{
    .bottomMargin 
     {
        margin-bottom: 60px;
     }
}
```